### PR TITLE
Use pure python to download demodata_geolife.gpkg

### DIFF
--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -329,7 +329,7 @@
    ],
    "source": [
     "t_start = datetime.now()\n",
-    "df = read_file('demodata_geolife.gpkg')\n",
+    "df = read_file(filename)\n",
     "df['t'] = pd.to_datetime(df['t'])\n",
     "df = df.set_index('t')\n",
     "print(\"Finished reading {} rows in {}\".format(len(df),datetime.now() - t_start))\n",

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -17,6 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import urllib\n",
+    "import os\n",
     "import pandas as pd\n",
     "from geopandas import GeoDataFrame, read_file\n",
     "from shapely.geometry import Point, LineString, Polygon\n",
@@ -258,7 +260,13 @@
     }
    ],
    "source": [
-    "!wget https://github.com/anitagraser/movingpandas/raw/master/demo/demodata_geolife.gpkg"
+    "url = 'https://github.com/anitagraser/movingpandas/raw/master/demo/demodata_geolife.gpkg'\n",
+    "filename = url.split('/')[-1] \n",
+    "\n",
+    "response = urllib.request.urlopen(url)\n",
+    "content = response.read()\n",
+    "with open(filename, 'wb' ) as f:\n",
+    "    f.write( content )\n"
    ]
   },
   {
@@ -280,7 +288,7 @@
     }
    ],
    "source": [
-    "!ls"
+    "assert(os.path.exists(filename))"
    ]
   },
   {


### PR DESCRIPTION
Remove dependency on external `wget` and `ls` in the getting_started.ipynb notebook.
