### PR TITLE
Trajectory.is_latlon() update for GeoPandas 0.7

### DIFF
--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -87,7 +87,7 @@ class Trajectory:
         """
         Generate an interactive plot using hvplot.
 
-        The following parameters are set by default: geo=True, tiles='OSM'. 
+        The following parameters are set by default: geo=True, tiles='OSM'.
 
         Parameters
         ----------
@@ -120,10 +120,10 @@ class Trajectory:
         -------
         bool
         """
-        if self.crs['init'] == from_epsg(4326)['init']:
-            return True
-        else:
-            return False
+        from pyproj import CRS
+
+        crs = CRS.from_user_input(self.crs)
+        return crs.is_geographic
 
     def to_crs(self, crs):
         """
@@ -368,7 +368,7 @@ class Trajectory:
         if not segment.is_valid():
             raise RuntimeError("Failed to extract valid trajectory segment between {} and {}".format(t1, t2))
         return segment
-    
+
     def _compute_distance(self, row):
         pt0 = row['prev_pt']
         pt1 = row['geometry']
@@ -380,8 +380,8 @@ class Trajectory:
             dist_meters = measure_distance_spherical(pt0, pt1)
         else:  # The following distance will be in CRS units that might not be meters!
             dist_meters = measure_distance_euclidean(pt0, pt1)
-        return dist_meters  
-    
+        return dist_meters
+
     def _add_prev_pt(self, force=True):
         """
         Create a shifted geometry column with previous positions.
@@ -389,7 +389,7 @@ class Trajectory:
         if 'prev_pt' not in self.df.columns or force:
             # TODO: decide on default enforcement behavior
             self.df = self.df.assign(prev_pt=self.df.geometry.shift())
-        
+
     def get_length(self):
         """
         Return the length of the trajectory.
@@ -424,7 +424,7 @@ class Trajectory:
             return calculate_initial_compass_bearing(pt0, pt1)
         else:
             return azimuth(pt0, pt1)
-    
+
     def _compute_heading(self, row):
         pt0 = row['prev_pt']
         pt1 = row['geometry']
@@ -566,7 +566,7 @@ class Trajectory:
             Trajectory segment intersecting with the feature
         """
         return intersection(self, feature, pointbased)
-        
+
     def split_by_date(self, mode='day'):
         """
         Split trajectory into subtrajectories using regular time intervals.

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -5,7 +5,6 @@ import sys
 
 from shapely.affinity import translate
 from shapely.geometry import Point, LineString
-from fiona.crs import from_epsg
 from datetime import datetime
 from pandas import Grouper
 
@@ -114,7 +113,7 @@ class Trajectory:
 
     def is_latlon(self):
         """
-        Return whether the trajectory CRS is WGS 84.
+        Return whether the trajectory CRS is geographic.
 
         Returns
         -------


### PR DESCRIPTION
Geopandas 0.7 will come with pyproj.CRS class under gdf.crs, so following will not work in the next release as it expects `self.crs` to be a dict. See https://github.com/geopandas/geopandas/pull/1101 for details. 

https://github.com/anitagraser/movingpandas/blob/01417e5b2ab8e3b06f8060cbcee934673ea7b4e4/movingpandas/trajectory.py#L115-L126

This fix ensures compatibility with future releases of geopandas as well as older ones. `crs.is_geographic` checks for any lon/lat projection, not only WGS84. I assume that it is expected behaviour anyway.

cc https://github.com/pyOpenSci/software-review/issues/18