### PR TITLE
Preserve the coordinate reference system when returning geodataframes

### DIFF
--- a/movingpandas/tests/test_trajectory_aggregator.py
+++ b/movingpandas/tests/test_trajectory_aggregator.py
@@ -37,5 +37,5 @@ class TestTrajectoryCollectionAggregator:
         assert self.trajectory_aggregator_latlon.get_flows_gdf().crs == CRS_LATLON
 
     def test_get_clusters_gdf_crs(self):
-        assert self.trajectory_aggregator.get_flows_gdf().crs == CRS_METRIC
-        assert self.trajectory_aggregator_latlon.get_flows_gdf().crs == CRS_LATLON
+        assert self.trajectory_aggregator.get_clusters_gdf().crs == CRS_METRIC
+        assert self.trajectory_aggregator_latlon.get_clusters_gdf().crs == CRS_LATLON

--- a/movingpandas/tests/test_trajectory_aggregator.py
+++ b/movingpandas/tests/test_trajectory_aggregator.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+from geopandas import GeoDataFrame
+from shapely.geometry import Point
+from fiona.crs import from_epsg
+from datetime import datetime, timedelta
+from movingpandas.trajectory_collection import TrajectoryCollection
+from movingpandas.trajectory_aggregator import TrajectoryCollectionAggregator
+
+
+CRS_METRIC = from_epsg(31256)
+CRS_LATLON = from_epsg(4326)
+
+
+class TestTrajectoryCollectionAggregator:
+
+    def setup_method(self):
+        df = pd.DataFrame([
+            {'id': 1, 'obj': 'A', 'geometry': Point(0, 0), 't': datetime(2018,1,1,12,0,0), 'val': 9, 'val2': 'a'},
+            {'id': 1, 'obj': 'A', 'geometry': Point(6, 0), 't': datetime(2018,1,1,12,6,0), 'val': 5, 'val2': 'b'},
+            {'id': 1, 'obj': 'A', 'geometry': Point(6, 6), 't': datetime(2018,1,1,14,10,0), 'val': 2, 'val2': 'c'}
+        ]).set_index('t')
+        self.geo_df = GeoDataFrame(df, crs=CRS_METRIC)
+        self.collection = TrajectoryCollection(self.geo_df, 'id', obj_id_col='obj')
+        self.trajectory_aggregator = TrajectoryCollectionAggregator(self.collection, 100, 0, min_stop_duration=timedelta(hours=12).seconds)
+        self.geo_df_latlon = GeoDataFrame(df, crs=CRS_LATLON)
+        self.collection_latlon = TrajectoryCollection(self.geo_df_latlon, 'id', obj_id_col='obj')
+        self.trajectory_aggregator_latlon = TrajectoryCollectionAggregator(self.collection_latlon, 100, 0, min_stop_duration=timedelta(hours=12).seconds)
+
+    def test_get_significant_points_gdf_crs(self):
+        assert self.trajectory_aggregator.get_significant_points_gdf().crs == CRS_METRIC
+        assert self.trajectory_aggregator_latlon.get_significant_points_gdf().crs == CRS_LATLON
+
+    def test_get_flows_gdf_crs(self):
+        assert self.trajectory_aggregator.get_flows_gdf().crs == CRS_METRIC
+        assert self.trajectory_aggregator_latlon.get_flows_gdf().crs == CRS_LATLON
+
+    def test_get_clusters_gdf_crs(self):
+        assert self.trajectory_aggregator.get_flows_gdf().crs == CRS_METRIC
+        assert self.trajectory_aggregator_latlon.get_flows_gdf().crs == CRS_LATLON

--- a/movingpandas/trajectory_aggregator.py
+++ b/movingpandas/trajectory_aggregator.py
@@ -28,6 +28,10 @@ class TrajectoryCollectionAggregator:
             Minimum angle for significant point extraction
         """
         self.traj_collection = traj_collection
+        if self.traj_collection.trajectories:
+            self._crs = traj_collection.trajectories[0].crs
+        else:
+            self._crs = None
         self.max_distance = max_distance
         self.min_distance = min_distance
         self.min_stop_duration = min_stop_duration
@@ -55,7 +59,7 @@ class TrajectoryCollectionAggregator:
         if not self.significant_points:
             self._extract_significant_points()
         df = DataFrame(self.significant_points, columns=['geometry'])
-        return GeoDataFrame(df)
+        return GeoDataFrame(df, crs=self._crs)
 
     def get_clusters_gdf(self):
         """
@@ -70,7 +74,7 @@ class TrajectoryCollectionAggregator:
             self._cluster_significant_points()
         df = DataFrame([cluster.centroid for cluster in self.clusters], columns=['geometry'])
         df['n'] = [len(cluster.points) for cluster in self.clusters]
-        return GeoDataFrame(df)
+        return GeoDataFrame(df, crs=self._crs)
 
     def get_flows_gdf(self):
         """
@@ -83,7 +87,7 @@ class TrajectoryCollectionAggregator:
         """
         if not self.flows:
             self._compute_flows_between_clusters()
-        return GeoDataFrame(self.flows)
+        return GeoDataFrame(self.flows, crs=self._crs)
 
     def _extract_significant_points(self):
         significant_points = []
@@ -124,7 +128,7 @@ class _PtsExtractor:
     def find_significant_points(self):
         while self.j < self.n - 1:
             if self.is_representative_max_distance():
-                self.significant_points.append(self.traj.df.iloc[self.j].geometry)
+                self.significant_points.append(self.traj.df.iloc[self.j][self.traj.get_geom_column_name()])
                 self.i = self.j
                 self.j = self.i + 1
                 continue
@@ -133,7 +137,7 @@ class _PtsExtractor:
                     d_time = self.traj.df.iloc[self.k - 1].name - self.traj.df.iloc[self.j].name
                     if d_time >= self.min_stop_duration:
                         # print("significant stop ({1}) at {0}".format(self.j,d_time))
-                        self.significant_points.append(self.traj.df.iloc[self.j].geometry)
+                        self.significant_points.append(self.traj.df.iloc[self.j][self.traj.get_geom_column_name()])
                         self.i = self.j
                         self.j = self.k
                         continue
@@ -144,7 +148,7 @@ class _PtsExtractor:
                 a_turn = self.compute_angle_between_vectors()
                 if a_turn >= self.min_angle and a_turn <= (360 - self.min_angle):
                     # print("significant angle ({0}) at {1}".format(a_turn,self.j))
-                    self.significant_points.append(self.traj.df.iloc[self.j].geometry)
+                    self.significant_points.append(self.traj.df.iloc[self.j][self.traj.get_geom_column_name()])
                     self.i = self.j
                     self.j = self.k
                 else:
@@ -154,17 +158,17 @@ class _PtsExtractor:
         return self.significant_points
 
     def compute_angle_between_vectors(self):
-        p_i = self.traj.df.iloc[self.i].geometry
-        p_j = self.traj.df.iloc[self.j].geometry
-        p_k = self.traj.df.iloc[self.k].geometry
+        p_i = self.traj.df.iloc[self.i][self.traj.get_geom_column_name()]
+        p_j = self.traj.df.iloc[self.j][self.traj.get_geom_column_name()]
+        p_k = self.traj.df.iloc[self.k][self.traj.get_geom_column_name()]
         azimuth_ij = azimuth(p_i, p_j)
         azimuth_jk = azimuth(p_j, p_k)
         return angular_difference(azimuth_ij, azimuth_jk)
 
     def more_points_further_than_min_distance(self):
         for self.k in range(self.j + 1, self.n):
-            p_j = self.traj.df.iloc[self.j].geometry
-            p_k = self.traj.df.iloc[self.k].geometry
+            p_j = self.traj.df.iloc[self.j][self.traj.get_geom_column_name()]
+            p_k = self.traj.df.iloc[self.k][self.traj.get_geom_column_name()]
             if self.traj.is_latlon:
                 d_space_j_k = measure_distance_spherical(p_j, p_k)
             else:
@@ -174,8 +178,8 @@ class _PtsExtractor:
         return False
 
     def is_representative_max_distance(self):
-        p_i = self.traj.df.iloc[self.i].geometry
-        p_j = self.traj.df.iloc[self.j].geometry
+        p_i = self.traj.df.iloc[self.i][self.traj.get_geom_column_name()]
+        p_j = self.traj.df.iloc[self.j][self.traj.get_geom_column_name()]
         if self.traj.is_latlon:
             d_space = measure_distance_spherical(p_i, p_j)
         else:
@@ -288,7 +292,7 @@ class _SequenceGenerator:
         this_sequence = []
         prev_cell_id = None
         for t, row in trajectory.df.iterrows():
-            nearest_id = self.get_nearest(row.geometry)
+            nearest_id = self.get_nearest(row[trajectory.get_geom_column_name()])
             nearest_cell = self.id_to_centroid[nearest_id][0]
             nearest_cell_id = nearest_cell.name
             if len(this_sequence) >= 1:


### PR DESCRIPTION
This sets the coordinate reference system to be the same as the source coordinate reference system of the trajectories.