### PR TITLE
Add trajectory collection pandas df

### DIFF
--- a/movingpandas/trajectory_collection.py
+++ b/movingpandas/trajectory_collection.py
@@ -43,6 +43,7 @@ class TrajectoryCollection:
             self.trajectories = data
         else:
             self.trajectories = self._df_to_trajectories(data, traj_id_col, obj_id_col)
+        self.df = pd.DataFrame([(traj.id, traj) for traj in self.trajectories], columns=["id", "trajectory"])
 
     def __len__(self):
         return len(self.trajectories)
@@ -282,6 +283,9 @@ class TrajectoryCollection:
         """
         for traj in self.trajectories:
             traj.add_speed(overwrite)
+
+    def add_length(self):
+        self.df["length"] = self.df.trajectory.apply(lambda traj: traj.get_length())
 
     def get_min(self, column):
         """


### PR DESCRIPTION
Hello,

Trajectory class has a data frame attribute. What do you think about adding a data frame to the TrajectoryCollection class? This would allow performing analysis on the whole trajectory collection. 

Example: get the average length of a trip collection:

```
traj_collection.add_length()
traj_collection.df.length.mean()
```