### PR TITLE
Move the `hvplot` visualisation requirements to be optional installs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.7"
+  - "3.8"
 install:
  # Install conda
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -8,17 +9,8 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
-  - conda info
-
-  # Install dependencies
-  - conda env create --file=environment.yml
-  - source activate movingpandas
-  - conda install pytest-cov
-  - conda install codecov 
-
-  - conda list
-  - python -c "import geopandas; geopandas.show_versions();"
+  - pip install tox-travis
 script:
-  - pytest --cov-report xml --cov=movingpandas
+  - tox
 after_success:
-  - codecov # submit coverage  
+  - codecov # submit coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
-  - pip install tox-travis
+  - pip install tox-travis tox-conda
 script:
   - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
+  - conda install codecov
   - pip install tox-travis tox-conda
 script:
   - tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,32 @@ create a development environment that is separate from your existing Python
 environment so that you can make and test changes without compromising your
 own work environment.
 
+### Development library installation
+
+To setup you should install moving pandas in editable mode with:
+
+```bash
+pip install -e .
+pip install -r dev-requirements.txt
+```
+
+Alternately you can install the development requirements in a single line with:
+
+```bash
+pip install -e ".[dev]"
+``` 
+
 ### Run the tests
 
 Before submitting your changes for review, make sure to check that your changes
-do not break any tests by running: ``pytest``
+do not break any tests. There are two methods to run tests:
+
+1. To run tests in the current development environment run `pytest` or 
+   `pytest -cov=movingpandas` to check code coverage for the unit tests.
+2. To run more complete integration tests in multiple environments you can use `tox`
+   instead. **Note** this assumes you are developing in an Anaconda development
+   environment. Also, be warned running in this way takes *much* longer (and will
+   create 4 new Anaconda environments to work in).
 
 ### Raising Pull Requests
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *requirements.txt

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 MovingPandas implements a Trajectory class and corresponding methods based on **[GeoPandas](https://geopandas.org)**.
 
-Visit **[movingpandas.org](http://movingpandas.org)** for details! 
+Visit **[movingpandas.org](http://movingpandas.org)** for details!
 
 You can try MovingPandas in a MyBinder notebook - no installation required: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/anitagraser/movingpandas/binder-tag?filepath=tutorials/tutorial_getting_started.ipynb)
 
@@ -39,29 +39,28 @@ MovingPandas for Python >= 3.7 and all it's dependencies are available from [con
 
 **Conda status**
 
-[![Conda Recipe](https://img.shields.io/badge/recipe-movingpandas-green.svg)](https://anaconda.org/conda-forge/movingpandas) 
-[![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/movingpandas.svg)](https://anaconda.org/conda-forge/movingpandas) 
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/movingpandas.svg)](https://anaconda.org/conda-forge/movingpandas) 
+[![Conda Recipe](https://img.shields.io/badge/recipe-movingpandas-green.svg)](https://anaconda.org/conda-forge/movingpandas)
+[![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/movingpandas.svg)](https://anaconda.org/conda-forge/movingpandas)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/movingpandas.svg)](https://anaconda.org/conda-forge/movingpandas)
 [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/movingpandas.svg)](https://anaconda.org/conda-forge/movingpandas)
 
 Note that it is **NOT recommended** to install MovingPandas from [PyPI](https://pypi.org/project/movingpandas/)!
-If you're on Windows or Mac, many GeoPandas / MovingPandas dependencies cannot be pip installed 
+If you're on Windows or Mac, many GeoPandas / MovingPandas dependencies cannot be pip installed
 (for details see the corresponding notes in the [GeoPandas documentation](https://geopandas.readthedocs.io/en/latest/getting_started/install.html)).
-On Ubuntu, pip install fails on cartopy with "Proj 4.9.0 must be installed".
 
-## Development Installation 
+## Development Installation
 
 Use the following steps to run the notebooks using the current development version:
 
 ### Using conda
 
-**Linux/Mac**:  
+**Linux/Mac**:
 
 ```
 conda env create -f environment.yml
 ```
 
-**Windows**: 
+**Windows**:
 
 ```
 conda config --add channels conda-forge
@@ -90,7 +89,7 @@ Known issues:
 
 ### Develop mode
 
-To install MovingPandas in ["develop" or "editable" mode](https://python-packaging-tutorial.readthedocs.io/en/latest/setup_py.html#develop-mode) you may use: 
+To install MovingPandas in ["develop" or "editable" mode](https://python-packaging-tutorial.readthedocs.io/en/latest/setup_py.html#develop-mode) you may use:
 
 ```
 python setup.py develop
@@ -104,13 +103,13 @@ A detailed overview on how to contribute can be found in the [contributing guide
 
 ## Related Python Packages
 
-[scikit-mobility](https://github.com/scikit-mobility/scikit-mobility) is a similar package which also deals with movement data. 
-It implements TrajectoryDataFrames and FlowDataFrames on top of Pandas instead of GeoPandas. 
-There is little overlap in the covered use cases and implemented functionality (comparing 
-[MovingPandas tutorials](https://github.com/anitagraser/movingpandas/tree/master/tutorials) and 
-[scikit-mobility tutorials](https://github.com/scikit-mobility/tutorials)). 
-MovingPandas focuses on spatio-temporal data exploration with corresponding functions for data manipulation and analysis. 
-scikit-mobility on the other hand focuses on computing human mobility metrics, generating synthetic trajectories 
+[scikit-mobility](https://github.com/scikit-mobility/scikit-mobility) is a similar package which also deals with movement data.
+It implements TrajectoryDataFrames and FlowDataFrames on top of Pandas instead of GeoPandas.
+There is little overlap in the covered use cases and implemented functionality (comparing
+[MovingPandas tutorials](https://github.com/anitagraser/movingpandas/tree/master/tutorials) and
+[scikit-mobility tutorials](https://github.com/scikit-mobility/tutorials)).
+MovingPandas focuses on spatio-temporal data exploration with corresponding functions for data manipulation and analysis.
+scikit-mobility on the other hand focuses on computing human mobility metrics, generating synthetic trajectories
 and assessing privacy risks.
 
 ## Citation information

--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ The official documentation is hosted on **[ReadTheDocs](https://movingpandas.rea
 
 MovingPandas for Python >= 3.7 and all it's dependencies are available from [conda-forge](https://anaconda.org/conda-forge/movingpandas) and can be installed using `conda install -c conda-forge movingpandas`.
 
+Moving pandas can be installed via pip though this may be difficult; some of the dependencies cannot be pip installed (for details see the corresponding notes in the [GeoPandas documentation](https://geopandas.readthedocs.io/en/latest/getting_started/install.html)). *However* if you have the following required dependencies available then moving pandas can be installed via pip:
+
+- numpy
+- cython
+- matplotlib
+- shapely
+- pandas
+- geopandas
+- pyproj
+- rtree
+
+(in practice this is easily achieved by doing a `conda install -c conda-forge geopandas`).
+
+Doing this gives the option of using either:
+
+```bash
+pip install movingpandas
+```
+
+which will install the base `movingpandas`, or if you require plotting with holoviews, then you can use:
+
+```bash
+pip install "movingpandas[viz]"
+``` 
+
 **Conda status**
 
 [![Conda Recipe](https://img.shields.io/badge/recipe-movingpandas-green.svg)](https://anaconda.org/conda-forge/movingpandas)
@@ -92,7 +117,7 @@ Known issues:
 To install MovingPandas in ["develop" or "editable" mode](https://python-packaging-tutorial.readthedocs.io/en/latest/setup_py.html#develop-mode) you may use:
 
 ```
-python setup.py develop
+pip install -e .
 ```
 
 ## Contributing to MovingPandas [![GitHub contributors](https://img.shields.io/github/contributors/anitagraser/movingpandas.svg)](https://github.com/anitagraser/movingpandas/graphs/contributors)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+-r viz-requirements.txt
+pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
 -r viz-requirements.txt
 pytest
+pytest-xdist
 tox
 tox-conda
+tox-travis

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 -r viz-requirements.txt
 pytest
+tox
+tox-conda

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,4 +59,4 @@ html_static_path = ['_static']
 
 
 
-autodoc_mock_imports = ["hvplot", "proj", "pyproj", "cartopy", "geoviews", "contextily", "holoviews", "geopandas", "fiona", "shapely"]
+autodoc_mock_imports = ["hvplot", "proj", "pyproj", "geoviews", "contextily", "holoviews", "geopandas", "fiona", "shapely"]

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - hvplot
   - bokeh
   - proj
-  - cartopy
   - geoviews
   - scikit-learn
   - geopy

--- a/movingpandas/tests/markers.py
+++ b/movingpandas/tests/markers.py
@@ -1,0 +1,55 @@
+"""Custom skipper if a module succeeds in importing
+
+Most to make it a bit easier to ensure the hvplot raises an import error later
+on so that can be tested.
+"""
+from typing import Optional
+import sys
+
+from _pytest.outcomes import Skipped
+
+
+def importthenskip(modname: str, minversion: Optional[str] = None, reason: Optional[str] = None) -> None:
+    """Import the requested module and skip if successful.
+
+    :param str modname:
+        The name of the module to import.
+    :param str minversion:
+        If given and the import succeeds then the test is skipped if the the
+        imported module's ``__version__`` is at least this value
+    :param str reason:
+        If given, this reason is shown as the message when the module is imported
+
+    Example::
+
+        importthenskip("docutils")
+    """
+    import warnings
+
+    __tracebackhide__ = True
+    compile(modname, "", "eval")  # to catch syntaxerrors
+
+    with warnings.catch_warnings():
+        # Make sure to ignore ImportWarnings that might happen because
+        # of existing directories with the same name we're trying to
+        # import but without a __init__.py file.
+        warnings.simplefilter("ignore")
+        try:
+            __import__(modname)
+        except ImportError:
+            return
+    mod = sys.modules[modname]
+    if minversion is None:
+        if reason is None:
+            reason = "imported {!r}".format(modname)
+        raise Skipped(reason, allow_module_level=True)
+
+    verattr = getattr(mod, "__version__", None)
+    if minversion is not None:
+        # Imported lazily to improve start-up time.
+        from packaging.version import Version
+
+        if verattr is None or Version(verattr) >= Version(minversion):
+            raise Skipped(
+                "module {!r} has __version__ {!r}, at least: {!r}".format(modname, verattr, minversion), allow_module_level=True,
+            )

--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -270,7 +270,12 @@ class TestTrajectory:
         traj = Trajectory(geo_df, 1)
         traj.add_speed()
         traj.add_direction()
-        traj.hvplot()
+        try:
+            import holoviews
+        except ModuleNotFoundError:
+            traj.plot()
+        else:
+            traj.hvplot()
 
     def test_support_for_other_geometry_column_names(self):
         df = pd.DataFrame([
@@ -282,7 +287,12 @@ class TestTrajectory:
         traj = Trajectory(geo_df, 1)
         traj.add_speed()
         traj.add_direction()
-        traj.hvplot()
+        try:
+            import holoviews
+        except ModuleNotFoundError:
+            pass
+        else:
+            traj.hvplot()
 
     def test_support_for_other_time_column_names(self):
         df = pd.DataFrame([
@@ -294,7 +304,12 @@ class TestTrajectory:
         traj = Trajectory(geo_df, 1)
         traj.add_speed()
         traj.add_direction()
-        traj.hvplot()
+        try:
+            import holoviews
+        except ModuleNotFoundError:
+            pass
+        else:
+            traj.hvplot()
         traj.plot()
         traj.get_length()
         traj.to_linestring()

--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -10,6 +10,8 @@ from datetime import datetime, timedelta
 from fiona.crs import from_epsg
 from movingpandas.trajectory import Trajectory, DIRECTION_COL_NAME, SPEED_COL_NAME, MissingCRSWarning
 
+from .markers import importthenskip
+
 
 CRS_METRIC = from_epsg(31256)
 CRS_LATLON = from_epsg(4326)
@@ -228,6 +230,12 @@ class TestTrajectory:
         traj = make_traj([Node(0, 0), Node(10, 10, day=2)], None)
         plot = traj.hvplot()
         assert isinstance(plot, holoviews.core.overlay.Overlay)
+
+    def test_hvplot_fails_without_holoviews(self):
+        importthenskip('holoviews')
+        traj = make_traj([Node(0, 0), Node(10, 10, day=2)], None)
+        with pytest.raises(ImportError):
+            traj.hvplot()
 
     def test_tolinestring_does_not_alter_df(self):
         traj = self.default_traj_metric

--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -218,13 +218,13 @@ class TestTrajectory:
         assert isinstance(plot, Axes)
 
     def test_hvplot_exists(self):
-        import holoviews
+        holoviews = pytest.importorskip("holoviews")
         plot = self.default_traj_latlon.hvplot(geo=True)
         assert isinstance(plot, holoviews.core.overlay.Overlay)
         assert len(plot.Path.ddims) == 2
 
     def test_hvplot_exists_without_crs(self):
-        import holoviews
+        holoviews = pytest.importorskip("holoviews")
         traj = make_traj([Node(0, 0), Node(10, 10, day=2)], None)
         plot = traj.hvplot()
         assert isinstance(plot, holoviews.core.overlay.Overlay)
@@ -300,7 +300,7 @@ class TestTrajectory:
         traj.to_linestring()
         traj.to_linestringm_wkt()
 
-    """ 
+    """
     This test should work but fails in my PyCharm probably due to https://github.com/pyproj4/pyproj/issues/134
 
     def test_crs(self):
@@ -308,4 +308,3 @@ class TestTrajectory:
         new_df = traj.df.to_crs(epsg=3857)
         self.assertEqual(new_df.crs, from_epsg(3857))
     """
-

--- a/movingpandas/tests/test_trajectory_collection.py
+++ b/movingpandas/tests/test_trajectory_collection.py
@@ -9,6 +9,8 @@ from datetime import datetime, timedelta
 from copy import copy
 from movingpandas.trajectory_collection import TrajectoryCollection
 
+from .markers import importthenskip
+
 
 CRS_METRIC = from_epsg(31256)
 CRS_LATLON = from_epsg(4326)
@@ -117,6 +119,11 @@ class TestTrajectoryCollection:
         holoviews = pytest.importorskip("holoviews")
         result = self.collection_latlon.hvplot()
         assert isinstance(result, holoviews.core.overlay.Overlay)
+
+    def test_hvplot_fails_without_holoviews(self):
+        importthenskip('holoviews', minversion='1')
+        with pytest.raises(ImportError):
+            self.collection_latlon.hvplot()
 
     def test_plot_exist_column(self):
         from matplotlib.axes import Axes

--- a/movingpandas/tests/test_trajectory_collection.py
+++ b/movingpandas/tests/test_trajectory_collection.py
@@ -114,7 +114,7 @@ class TestTrajectoryCollection:
         assert isinstance(result, Axes)
 
     def test_hvplot_exists(self):
-        import holoviews
+        holoviews = pytest.importorskip("holoviews")
         result = self.collection_latlon.hvplot()
         assert isinstance(result, holoviews.core.overlay.Overlay)
 

--- a/movingpandas/trajectory_plotter.py
+++ b/movingpandas/trajectory_plotter.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import matplotlib.pyplot as plt
-import hvplot.pandas # seems to be necessary for the following import to work
-from holoviews import opts, dim
 
 
 class _TrajectoryPlotter:
@@ -80,6 +78,11 @@ class _TrajectoryPlotter:
         return ax
 
     def hvplot(self):
+        try:
+            import hvplot.pandas  # seems to be necessary for the following import to work
+            from holoviews import opts, dim
+        except ImportError:
+            raise ImportError('hvplot, bokeh, and geoviews must be installed for hvplot. Run `pip install "movingpandas[viz]"`')
         opts.defaults(opts.Overlay(width=self.width, height=self.height, active_tools=['wheel_zoom']))
         return self._hvplot_trajectory(self.data)
 
@@ -110,6 +113,11 @@ class _TrajectoryCollectionPlotter(_TrajectoryPlotter):
         return ax
 
     def hvplot(self):
+        try:
+            import hvplot.pandas  # seems to be necessary for the following import to work
+            from holoviews import opts, dim
+        except ImportError:
+            raise ImportError('hvplot, bokeh, and geoviews must be installed for hvplot. Run `pip install "movingpandas[viz]"`')
         opts.defaults(opts.Overlay(width=self.width, height=self.height, active_tools=['wheel_zoom']))
         for traj in self.data:
             overlay = self._hvplot_trajectory(traj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+matplotlib
+shapely
+pandas
+geopandas
+pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ shapely
 pandas
 geopandas
 pyproj
+rtree

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+cython
 matplotlib
 shapely
 pandas

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ def parse_requirements(path):
 # Packages that MovingPandas uses explicitly:
 INSTALL_REQUIRES = list(parse_requirements('requirements.txt'))
 VIZ_INSTALL_REQUIRES = list(parse_requirements('viz-requirements.txt'))
+DEV_INSTALL_REQUIRES = list(parse_requirements('dev-requirements.txt'))
 
 
 setuptools.setup(
@@ -46,6 +47,7 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=INSTALL_REQUIRES,
     extras_require={
-        'viz': VIZ_INSTALL_REQUIRES
+        'viz': VIZ_INSTALL_REQUIRES,
+        'dev': DEV_INSTALL_REQUIRES
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,30 @@ import setuptools
 with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()
 
+
+def parse_requirements(path):
+    """
+    Parse requirements files to allow easier separation in to groups.
+
+    Keep the line filtering simple, but we could go the whole way in implementing
+    https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+    if required.
+    """
+    for line in open(path):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+
+        if line.startswith('-r'): # looking at another requirements file
+            yield from parse_requirements(line[2:].strip())
+        else:
+            yield line
+
+
 # Packages that MovingPandas uses explicitly:
-INSTALL_REQUIRES = ['numpy', 'matplotlib', 'shapely', 'pandas', 'geopandas', 'hvplot', 'bokeh', 'cartopy', 'geoviews', 'pyproj']
+INSTALL_REQUIRES = list(parse_requirements('requirements.txt'))
+VIZ_INSTALL_REQUIRES = list(parse_requirements('viz-requirements.txt'))
+
 
 setuptools.setup(
     name="movingpandas",
@@ -22,5 +44,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.7',
-    install_requires=INSTALL_REQUIRES
+    install_requires=INSTALL_REQUIRES,
+    extras_require={
+        'viz': VIZ_INSTALL_REQUIRES
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ conda_channels=
     conda-forge
     default
 commands=
-    pytest {posargs}
+    pytest -n auto {posargs}
 
 [testenv:viz]
 deps=
@@ -37,4 +37,4 @@ conda_channels=
     conda-forge
     default
 commands=
-    pytest movingpandas {posargs}
+    pytest -n auto {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+envlist =
+    {py37,py38}-{stable,dev}
+
+[testenv]
+deps=
+    pytest
+    pytest-xdist
+conda_deps=
+    numpy
+    matplotlib
+    shapely
+    pandas
+    geopandas
+    pyproj
+conda_channels=
+    conda-forge
+    default
+commands=
+    pytest {posargs}
+
+[testenv:viz]
+deps=
+    pytest
+    pytest-xdist
+conda_deps=
+    numpy
+    matplotlib
+    shapely
+    pandas
+    geopandas
+    pyproj
+    hvplot
+    bokeh>=2.0.0
+    geoviews
+conda_channels=
+    conda-forge
+    default
+commands=
+    pytest movingpandas {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 envlist =
-    {py37,py38}-{stable,dev}
+    clean
+    {py37,py38}-{viz,noviz}
+    report
 
 [testenv]
 deps=
     pytest
+    pytest-cov
     pytest-xdist
+    {py37,py38}: clean
 conda_deps=
     numpy
     matplotlib
@@ -13,28 +17,25 @@ conda_deps=
     pandas
     geopandas
     pyproj
+    rtree
+    viz: holoviews
+    viz: hvplot
+    viz: bokeh>=2.0.0
+    viz: geoviews
 conda_channels=
     conda-forge
     default
 commands=
-    pytest -n auto {posargs}
+    pytest -n auto --cov-append --cov=movingpandas {posargs}
 
-[testenv:viz]
-deps=
-    pytest
-    pytest-xdist
-conda_deps=
-    numpy
-    matplotlib
-    shapely
-    pandas
-    geopandas
-    pyproj
-    hvplot
-    bokeh>=2.0.0
-    geoviews
-conda_channels=
-    conda-forge
-    default
-commands=
-    pytest -n auto {posargs}
+[testenv:clean]
+conda_deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:report]
+conda_deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ conda_deps=
     geopandas
     pyproj
     rtree
+    cython
     viz: holoviews
     viz: hvplot
     viz: bokeh>=2.0.0

--- a/viz-requirements.txt
+++ b/viz-requirements.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
 hvplot
 bokeh
-cartopy
 geoviews

--- a/viz-requirements.txt
+++ b/viz-requirements.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+hvplot
+bokeh
+cartopy
+geoviews

--- a/viz-requirements.txt
+++ b/viz-requirements.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 hvplot
-bokeh
+bokeh>=2.0.0
 geoviews


### PR DESCRIPTION
Closes #78

Finalise the work on separating the plotting libraries to make them
optional. This includes:

1. Remove references to `cartopy` which isn't used
2. Update setup.py to parse requirements.txt files
3. Have a base `requirements.txt`, a `via-requirements.txt` and a `dev-requirements.txt` which install
   1. The base libraries required for movingpandas (`requirements.txt`)
   2. The additional visualisation libraries for the hvplot function (`viz-requirements.txt`)
   3. The libraries required for development, specifically unit testing libraries (`dev-requirements.txt`)
4. Include optional installs in `setup.py` so you can:
   - `pip install movingpandas`
   - `pip install "movingpandas[viz]"`
   - `pip install "movingpandas[dev]"`
5. Update the unit tests so that testing the `hvplot` function is skipped when holoviews is not installed
6. Create a `tox` test script to test Python 3.7 and 3.8 with and without the visualisation libraries
   - This uses the `tox-conda` library to use conda for installs rather than the standard `venv`
7. Update the travis configuration (including `tox-travis`) to use `tox` for testing and to combine the coverage report
   - Unit tests should be run with `tox` from the command line, and you should end up with 6 skipped tests - 3 each from the 3.7 and 3.8 environments. Be warned - this can take a while to set up the environmnents the first time around! And travis will take 10 - 12 minutes to run!