### PR TITLE
Fix a crash when points are aligned

### DIFF
--- a/movingpandas/point_clusterer.py
+++ b/movingpandas/point_clusterer.py
@@ -53,8 +53,10 @@ class _Grid:
         self.y_min = bbox[1]
         self.cell_size = cell_size
         self.cells = []
-        self.n_rows = int(math.ceil(h / self.cell_size))
-        self.n_cols = int(math.ceil(w / self.cell_size))
+        # in the rare case that the points are horizontal or vertical,
+        # fallback to a 1x1 cell matrix
+        self.n_rows = max(1, int(math.ceil(h / self.cell_size)))
+        self.n_cols = max(1, int(math.ceil(w / self.cell_size)))
         for i in range(0, self.n_cols):
             self.cells.append([])
             for j in range(0, self.n_rows):

--- a/movingpandas/tests/test_point_clusterer.py
+++ b/movingpandas/tests/test_point_clusterer.py
@@ -33,3 +33,27 @@ class TestClustering:
         assert len(actual) == len(expected)
         for pt in expected:
             assert pt in actual
+
+    def test_cluster_horizontal_points(self):
+        pts = [Point(0, 2), Point(0, 6), Point(0, 4), Point(0, 3), Point(0, 5), Point(0, 7)]
+        expected = GeoDataFrame(pd.DataFrame([{'geometry': Point(0, 4.5), 'n': 6}]))
+        actual = PointClusterer(pts, max_distance=5, is_latlon=False).get_clusters()
+        actual = [(c.centroid, len(c.points)) for c in actual]
+        expected = [(c.geometry, c.n) for key, c in expected.iterrows()]
+        assert len(actual) == len(expected)
+        for pt in expected:
+            assert pt in actual
+
+    def test_cluster_vertical_points(self):
+        pts = [Point(0, 2), Point(6, 2), Point(6, 2), Point(0.2, 2), Point(6.2, 2), Point(6.2, 2)]
+        expected = GeoDataFrame(pd.DataFrame([
+            {'geometry': Point(0.1, 2), 'n': 2},
+            {'geometry': Point(6.1, 2), 'n': 4}]
+        ))
+        actual = PointClusterer(pts, max_distance=5, is_latlon=False).get_clusters()
+        actual = [(c.centroid, len(c.points)) for c in actual]
+        expected = [(c.geometry, c.n) for key, c in expected.iterrows()]
+        assert len(actual) == len(expected)
+        print([str(c) for p in actual for c in p])
+        for pt in expected:
+            assert pt in actual


### PR DESCRIPTION
If the points are aligned either vertically or horizontally the point
clusterer was crashing as the number of rows or cols would be zero.