### PR TITLE
Speed up mrr_diagonal() by using MultiPoint instead of LineString

### DIFF
--- a/movingpandas/geometry_utils.py
+++ b/movingpandas/geometry_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from math import sin, cos, atan2, radians, degrees, sqrt, pi
-from shapely.geometry import Point, LineString
+from shapely.geometry import MultiPoint, Point
 from geopy import distance
 
 
@@ -137,7 +137,7 @@ def mrr_diagonal(geom, spherical=False):
         return 0
     if len(geom) == 2:
         return _measure_distance(geom[0], geom[1], spherical)
-    mrr = LineString(geom).minimum_rotated_rectangle
+    mrr = MultiPoint(geom).minimum_rotated_rectangle
     try:  # usually mrr is a Polygon
         x, y = mrr.exterior.coords.xy
     except AttributeError:  # thrown if mrr is a LineString


### PR DESCRIPTION
Constructing LineStrings is more expensive than constructing a
MultiPoint, and from the minimum rotated rectangle perspective it should
make no difference if it is a set of lines or a set of points.