### PR TITLE
Create Github action for pre-commit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, 0.**]
+  pull_request:
+    branches: [master, 0.**]
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
Related to https://github.com/anitagraser/movingpandas/issues/143

In theory after this merges when some makes a PR it'll kick off pre-commit checks

This taken directly from https://github.com/geopandas/geopandas/blob/master/.github/workflows/tests.yaml#L1-L22