### PR TITLE
black and flake8 trajectory_aggregator.py

### DIFF
--- a/movingpandas/trajectory_aggregator.py
+++ b/movingpandas/trajectory_aggregator.py
@@ -117,7 +117,7 @@ class TrajectoryCollectionAggregator:
         return GeoDataFrame(self.flows, crs=self._crs)
 
     def _extract_significant_points(self):
-        sig_points = []
+        significant_points = []
         for traj in self.traj_collection:
             a = _PtsExtractor(
                 traj,
@@ -126,8 +126,9 @@ class TrajectoryCollectionAggregator:
                 self.min_stop_duration,
                 self.min_angle,
             )
-            sig_points = sig_points + a.find_significant_points()
-        return sig_points
+            a_significant_points = a.find_significant_points()
+            significant_points = significant_points + a_significant_points
+        return significant_points
 
     def _compute_flows_between_clusters(self):
         sg = _SequenceGenerator(self.get_clusters_gdf(), self.traj_collection)

--- a/movingpandas/trajectory_aggregator.py
+++ b/movingpandas/trajectory_aggregator.py
@@ -6,31 +6,47 @@ from shapely.geometry import LineString
 from shapely.ops import nearest_points
 
 from movingpandas.point_clusterer import PointClusterer
-from .geometry_utils import azimuth, angular_difference, measure_distance_geodesic, measure_distance_euclidean
+from .geometry_utils import (
+    azimuth,
+    angular_difference,
+    measure_distance_geodesic,
+    measure_distance_euclidean,
+)
 
 
 class TrajectoryCollectionAggregator:
-    def __init__(self, traj_collection, max_distance, min_distance, min_stop_duration, min_angle=45):
+    def __init__(
+        self,
+        traj_collection,
+        max_distance,
+        min_distance,
+        min_stop_duration,
+        min_angle=45,
+    ):
         """
-        Aggregates trajectories by extracting significant points, clustering those points, and extracting
-        flows between clusters.
-
-        Based on the algorithm described by Andrienko, N., & Andrienko, G. (2011). Spatial generalization and
-        aggregation of massive movement data. IEEE Transactions on visualization and computer graphics, 17(2), 205-219.
+        Aggregates trajectories by extracting significant points,
+        clustering those points, and extracting flows between clusters.
 
         Parameters
         ----------
         traj_collection : TrajectoryCollection
             TrajectoryCollection to be aggregated
         max_distance : float
-            Maximum distance between significant points (distance is calculated in CRS units, except if the CRS
-            is geographic, e.g. EPSG:4326 WGS84, then distance is calculated in meters)
+            Maximum distance between significant points (distance is
+            calculated in CRS units, except if the CRS is geographic, e.g.
+            EPSG:4326 WGS84, then distance is calculated in meters)
         min_distance : float
             Minimum distance between significant points
         min_stop_duration : integer
             Minimum duration required for stop detection (in seconds)
         min_angle : float
             Minimum angle for significant point extraction
+
+        References
+        ----------
+        * Andrienko, N., & Andrienko, G. (2011). Spatial generalization and
+          aggregation of massive movement data. IEEE Transactions on
+          visualization and computer graphics, 17(2), 205-219.
         """
         self.traj_collection = traj_collection
         if self.traj_collection.trajectories:
@@ -42,15 +58,16 @@ class TrajectoryCollectionAggregator:
         self.min_stop_duration = min_stop_duration
         self.min_angle = min_angle
         self.is_latlon = self.traj_collection.trajectories[0].is_latlon
-        #print('Extracting significant points ...')
+        # print('Extracting significant points ...')
         self.significant_points = self._extract_significant_points()
-        #print('  No. significant points: {}'.format(len(self.significant_points)))
-        #print('Clustering significant points ...')
-        self.clusters = PointClusterer(self.significant_points, self.max_distance, self.is_latlon).get_clusters()
-        #print('  No. clusters: {}'.format(len(self.clusters)))
-        #print('Computing flows ...')
+        # print('Clustering significant points ...')
+        self.clusters = PointClusterer(
+            self.significant_points, self.max_distance, self.is_latlon
+        ).get_clusters()
+        # print('  No. clusters: {}'.format(len(self.clusters)))
+        # print('Computing flows ...')
         self.flows = self._compute_flows_between_clusters()
-        #print('Flows ready!')
+        # print('Flows ready!')
 
     def get_significant_points_gdf(self):
         """
@@ -63,7 +80,7 @@ class TrajectoryCollectionAggregator:
         """
         if not self.significant_points:
             self._extract_significant_points()
-        df = DataFrame(self.significant_points, columns=['geometry'])
+        df = DataFrame(self.significant_points, columns=["geometry"])
         return GeoDataFrame(df, crs=self._crs)
 
     def get_clusters_gdf(self):
@@ -73,12 +90,16 @@ class TrajectoryCollectionAggregator:
         Returns
         -------
         GeoDataFrame
-            Cluster centroids, incl. the number of clustered significant points (n)
+            Cluster centroids, incl. the number of clustered significant
+            points (n).
         """
         if not self.clusters:
             self._cluster_significant_points()
-        df = DataFrame([cluster.centroid for cluster in self.clusters], columns=['geometry'])
-        df['n'] = [len(cluster.points) for cluster in self.clusters]
+        df = DataFrame(
+            [cluster.centroid for cluster in self.clusters],
+            columns=["geometry"],
+        )
+        df["n"] = [len(cluster.points) for cluster in self.clusters]
         return GeoDataFrame(df, crs=self._crs)
 
     def get_flows_gdf(self):
@@ -88,18 +109,25 @@ class TrajectoryCollectionAggregator:
         Returns
         -------
         GeoDataFrame
-            Flow lines, incl. the number of trajectories summarized in the flow (weight)
+            Flow lines, incl. the number of trajectories summarized in the
+            flow (weight).
         """
         if not self.flows:
             self._compute_flows_between_clusters()
         return GeoDataFrame(self.flows, crs=self._crs)
 
     def _extract_significant_points(self):
-        significant_points = []
+        sig_points = []
         for traj in self.traj_collection:
-            a = _PtsExtractor(traj, self.max_distance, self.min_distance, self.min_stop_duration, self.min_angle)
-            significant_points = significant_points + a.find_significant_points()
-        return significant_points
+            a = _PtsExtractor(
+                traj,
+                self.max_distance,
+                self.min_distance,
+                self.min_stop_duration,
+                self.min_angle,
+            )
+            sig_points = sig_points + a.find_significant_points()
+        return sig_points
 
     def _compute_flows_between_clusters(self):
         sg = _SequenceGenerator(self.get_clusters_gdf(), self.traj_collection)
@@ -107,7 +135,9 @@ class TrajectoryCollectionAggregator:
 
 
 class _PtsExtractor:
-    def __init__(self, traj, max_distance, min_distance, min_stop_duration, min_angle=45):
+    def __init__(
+        self, traj, max_distance, min_distance, min_stop_duration, min_angle=45
+    ):
         self.traj = traj
         self.traj_geom = traj.df[traj.get_geom_column_name()]
         self.n = self.traj.df.geometry.count()
@@ -115,7 +145,10 @@ class _PtsExtractor:
         self.min_distance = min_distance
         self.min_stop_duration = min_stop_duration
         self.min_angle = min_angle
-        self.significant_points = [self.traj.get_start_location(), self.traj.get_end_location()]
+        self.significant_points = [
+            self.traj.get_start_location(),
+            self.traj.get_end_location(),
+        ]
 
     def find_significant_points(self):
         i = 0
@@ -128,14 +161,16 @@ class _PtsExtractor:
                 continue
             k, has_points = self.locate_points_beyond_min_distance(j)
             if has_points:
-                #print(f"has points (i={i} | j={j} | k={k})")
+                # print(f"has points (i={i} | j={j} | k={k})")
                 if k > j + 1:
                     if self.is_significant_stop(j, k):
                         self.add_point(j)
                         i = j
                         j = k
                         continue
-                    else:  # compute the average spatial position to represent the similar points
+                    # compute the average spatial position to represent the
+                    # similar points
+                    else:
                         m = j + (k - 1 - j) / 2
                         j = int(m)
                 if self.is_significant_turn(i, j, k):
@@ -150,7 +185,9 @@ class _PtsExtractor:
 
     def is_significant_turn(self, i, j, k):
         turn_angle = self.compute_angle_between_vectors(i, j, k)
-        return turn_angle >= self.min_angle and turn_angle <= (360 - self.min_angle)
+        a = turn_angle >= self.min_angle
+        b = turn_angle <= (360 - self.min_angle)
+        return a and b
 
     def is_significant_stop(self, j, k):
         delta_t = self.traj.df.iloc[k - 1].name - self.traj.df.iloc[j].name
@@ -202,7 +239,19 @@ class _SequenceGenerator:
         self.cells = cells
         self.cells_union = cells.geometry.unary_union
 
-        self.id_to_centroid = {i: [f, [0, 0, 0, 0, 0]] for i, f in cells.iterrows()}
+        self.id_to_centroid = {
+            i: [
+                f,
+                [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+            ]
+            for i, f in cells.iterrows()
+        }
         self.sequences = {}
         for traj in traj_collection:
             self.evaluate_trajectory(traj)
@@ -210,7 +259,9 @@ class _SequenceGenerator:
     def evaluate_trajectory(self, trajectory):
         this_sequence = []
         prev_cell_id = None
-        for t, geom in trajectory.df[trajectory.get_geom_column_name()].iteritems():
+        for t, geom in trajectory.df[
+            trajectory.get_geom_column_name(),
+        ].iteritems():
             nearest_id = self.get_nearest(geom)
             nearest_cell = self.id_to_centroid[nearest_id][0]
             nearest_cell_id = nearest_cell.name
@@ -233,13 +284,11 @@ class _SequenceGenerator:
         for key, value in self.sequences.items():
             p1 = self.id_to_centroid[key[0]][0].geometry
             p2 = self.id_to_centroid[key[1]][0].geometry
-            lines.append({'geometry': LineString([p1, p2]), 'weight': value})
+            lines.append({"geometry": LineString([p1, p2]), "weight": value})
         return lines
 
-
     def get_nearest(self, pt):
-        nearest = self.cells.geometry.geom_equals(nearest_points(pt, self.cells_union)[1])
+        nearest = self.cells.geometry.geom_equals(
+            nearest_points(pt, self.cells_union)[1]
+        )
         return self.cells[nearest].iloc[0].name
-
-
-


### PR DESCRIPTION
Related to https://github.com/anitagraser/movingpandas/pull/171

trajectory_aggregator.py now passes black and flake8.

All lines lengths are < 79. Where possible it's good to do this rather than make an exception for flake8. It's true they are in conflict black will default 88 and flake8 79. I know it's a pain as there isn't a quick solution but  I got everything to be < 79 by:
 - Moving stuff to a new line in the doc string
 - Added a trailing comma to a list e.g. `[my, long, list]` to `[my, long, list,]`
 - Create new variables e.g.
```
        a = turn_angle >= self.min_angle
        b = turn_angle <= (360 - self.min_angle)
        return a and b
```

If tests don't pass I didn't something wrong
