### PR TITLE
Optimize stop point detection by avoid re-creating shapely objects

### DIFF
--- a/movingpandas/geometry_utils.py
+++ b/movingpandas/geometry_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from math import sin, cos, atan2, radians, degrees, sqrt, pi
-from shapely.geometry import MultiPoint, Point
+from shapely.geometry import Point
 from geopy import distance
 
 

--- a/movingpandas/geometry_utils.py
+++ b/movingpandas/geometry_utils.py
@@ -145,11 +145,11 @@ def mrr_diagonal(geom, spherical=False):
     Calculate the length of the diagonal of the minimum rotated rectangle of
     the input geometry.
     """
-    if len(geom) == 1:
+    if isinstance(geom, Point):
         return 0
     if len(geom) == 2:
         return _measure_distance(geom[0], geom[1], spherical)
-    mrr = MultiPoint(geom).minimum_rotated_rectangle
+    mrr = geom.minimum_rotated_rectangle
     try:  # usually mrr is a Polygon
         x, y = mrr.exterior.coords.xy
     except AttributeError:  # thrown if mrr is a LineString

--- a/movingpandas/tests/test_geometry_utils.py
+++ b/movingpandas/tests/test_geometry_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 from math import sqrt
-from shapely.geometry import Point
+from shapely.geometry import MultiPoint, Point
 from movingpandas.geometry_utils import (
     azimuth,
     calculate_initial_compass_bearing,
@@ -72,8 +72,11 @@ class TestGeometryUtils:
 
     def test_mrr_diagonal(self):
         assert mrr_diagonal(
-            [Point(0, 0), Point(0, 2), Point(2, 0), Point(2, 2)]
+            MultiPoint([Point(0, 0), Point(0, 2), Point(2, 0), Point(2, 2)])
         ) == sqrt(8)
+
+    def test_mrr_diagonal_one_point(self):
+        assert mrr_diagonal(Point(2, 3)) == 0
 
     def test_euclidean_distance(self):
         assert (measure_distance_euclidean(Point(0, 0), Point(0, 1))) == 1


### PR DESCRIPTION
Approximately half of the time of mrr_diagonal() is spent creating shapely MultiPoint
instances with the entire list of points.

In order to speed this up, iteratively add points to one single MultiPoint instance by
using the union() operator.

Also, instead of iterating over the dataframe rows and then select the desired column,
select the series just once and iterate over its values.