### PR TITLE
skip missing optional deps message on import

### DIFF
--- a/movingpandas/__init__.py
+++ b/movingpandas/__init__.py
@@ -29,8 +29,8 @@ from .tools._show_versions import show_versions  # noqa F401
 
 try:
     from .trajectory_smoother import KalmanSmootherCV  # noqa F401
-except ImportError as e:
-    print(f"INFO: {e}")
+except ImportError:
+    pass
 
 name = "movingpandas"
 __version__ = "0.10.rc1"


### PR DESCRIPTION
I realize I was in favor of this in https://github.com/anitagraser/movingpandas/issues/178

However, if you are not using `trajectory_smoother.py` I feel the message adds noise.

Moreso, i'm trying to capture the version in a shell environment as it's not currently possbile

```
export VERSION=$(python -c "import movingpandas; print(movingpandas.__version__)")
echo $VERSION
INFO: Missing optional dependencies. To use the trajectory smoother classes please install Stone Soup (see https://stonesoup.readthedocs.io/en/latest/#installation). 0.10.rc1
```

