### PR TITLE
Issue 249: Fixed typo in mrr_diagonal

### DIFF
--- a/movingpandas/geometry_utils.py
+++ b/movingpandas/geometry_utils.py
@@ -153,5 +153,5 @@ def mrr_diagonal(geom, spherical=False):
     try:  # usually mrr is a Polygon
         x, y = mrr.exterior.coords.xy
     except AttributeError:  # thrown if mrr is a LineString
-        return _measure_distance(Point(mrr.coords[0]), Point(mrr.coords[-1], spherical))
+        return _measure_distance(Point(mrr.coords[0]), Point(mrr.coords[-1]), spherical)
     return _measure_distance(Point(x[0], y[0]), Point(x[2], y[2]), spherical)

--- a/movingpandas/tests/test_geometry_utils.py
+++ b/movingpandas/tests/test_geometry_utils.py
@@ -112,3 +112,11 @@ class TestGeometryUtils:
     def test_azimuth_throws_type_error(self):
         with pytest.raises(TypeError):
             azimuth((0, 0), (0, 1))
+
+    def test_mrr_diagonal_linestring(self):
+        # Distance between NYC, NY USA and Los Angeles, CA USA is
+        # 3944411.0951634306 meters
+        assert mrr_diagonal(
+            MultiPoint([Point(-74.00597, 40.71427), Point(-74.00597, 40.71427), Point(-118.24368, 34.05223)]),
+            spherical=True
+        ) == pytest.approx(3944411)

--- a/movingpandas/tests/test_geometry_utils.py
+++ b/movingpandas/tests/test_geometry_utils.py
@@ -117,6 +117,12 @@ class TestGeometryUtils:
         # Distance between NYC, NY USA and Los Angeles, CA USA is
         # 3944411.0951634306 meters
         assert mrr_diagonal(
-            MultiPoint([Point(-74.00597, 40.71427), Point(-74.00597, 40.71427), Point(-118.24368, 34.05223)]),
-            spherical=True
+            MultiPoint(
+                [
+                    Point(-74.00597, 40.71427),
+                    Point(-74.00597, 40.71427),
+                    Point(-118.24368, 34.05223),
+                ]
+            ),
+            spherical=True,
         ) == pytest.approx(3944411)


### PR DESCRIPTION
Fixed typo in mrr_diagonal as described in issue #249 . Pytest tests ran and all passed.