### PR TITLE
Modify TrajectoryCollectionAggregator docstring to timedelta instead of int

### DIFF
--- a/movingpandas/trajectory_aggregator.py
+++ b/movingpandas/trajectory_aggregator.py
@@ -37,8 +37,8 @@ class TrajectoryCollectionAggregator:
             EPSG:4326 WGS84, then distance is calculated in meters)
         min_distance : float
             Minimum distance between significant points
-        min_stop_duration : integer
-            Minimum duration required for stop detection (in seconds)
+        min_stop_duration : datetime.timedelta
+            Minimum duration required for stop detection
         min_angle : float
             Minimum angle for significant point extraction
 


### PR DESCRIPTION
Expected parameter is actually timedelta and not int, adjusting the docstring to reflect that. 

Regarding the parameter type, timedelta is preferrable to int as discussed here: https://github.com/anitagraser/movingpandas/pull/279