### PR TITLE
Fix the accumulating ids in ValueChangeSplitter

### DIFF
--- a/movingpandas/tests/test_trajectory_splitter.py
+++ b/movingpandas/tests/test_trajectory_splitter.py
@@ -485,7 +485,7 @@ class TestTrajectorySplitter:
         assert split.trajectories[0].id == "1_0"
         assert split.trajectories[1].id == "2_0"
         assert split.trajectories[2].id == "2_1"
-    
+
     def test_split_by_value_change_multiprocessing(self):
         split = ValueChangeSplitter(self.collection).split(
             n_processes=2, col_name="val2"

--- a/movingpandas/tests/test_trajectory_splitter.py
+++ b/movingpandas/tests/test_trajectory_splitter.py
@@ -482,7 +482,10 @@ class TestTrajectorySplitter:
         )
         assert split.trajectories[2].to_linestring().wkt == "LINESTRING (16 16, 190 19)"
         assert split.get_crs() == "EPSG:31256"
-
+        assert split.trajectories[0].id == "1_0"
+        assert split.trajectories[1].id == "2_0"
+        assert split.trajectories[2].id == "2_1"
+    
     def test_split_by_value_change_multiprocessing(self):
         split = ValueChangeSplitter(self.collection).split(
             n_processes=2, col_name="val2"

--- a/movingpandas/trajectory_splitter.py
+++ b/movingpandas/trajectory_splitter.py
@@ -382,12 +382,13 @@ class ValueChangeSplitter(TrajectorySplitter):
                 df = df.sort_index(ascending=True)
             if len(df) > 1:
                 df = GeoDataFrame(df).set_crs(traj.df.crs)
-                traj = Trajectory(
-                    df,
-                    f"{traj.id}_{i}",
-                    traj_id_col=traj.get_traj_id_col(),
-                    x=traj.x,
-                    y=traj.y,
+                result.append(
+                    Trajectory(
+                        df,
+                        f"{traj.id}_{i}",
+                        traj_id_col=traj.get_traj_id_col(),
+                        x=traj.x,
+                        y=traj.y,
+                    )
                 )
-                result.append(traj)
         return TrajectoryCollection(result, min_length=min_length)


### PR DESCRIPTION
Solves #481 by preventing reusing the `traj` variable name and adding it straight to the list. There are no tests checking for this behavior, so no changes are needed in the test fixtures.