### PR TITLE
Add Trajectory.frechet_distance (towards #37)

### DIFF
--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -1175,6 +1175,31 @@ class TestTrajectory:
             point = Point(0, 0)
             self.default_traj_latlon.hausdorff_distance(point)
 
+    def test_frechet_distance(self):
+        from math import sqrt
+
+        traj = make_traj([Node(0, 0, day=1), Node(1, 1, day=2), Node(2, 2, day=3)])
+        point = Point(0, 0)
+        assert traj.frechet_distance(point) == sqrt(4 + 4)
+        line = LineString([(2, 0), (2, 4), (3, 4)])
+        assert traj.frechet_distance(line) == sqrt(4 + 1)
+        traj2 = make_traj([Node(2, 0, day=1), Node(2, 4, day=2), Node(3, 4, day=3)])
+        assert traj.frechet_distance(traj2) == sqrt(4 + 1)
+
+    def test_frechet_distance_units(self):
+        from math import sqrt
+
+        traj = make_traj([Node(0, 0, day=1), Node(1, 1, day=2), Node(2, 2, day=3)])
+        point = Point(0, 0)
+        assert traj.frechet_distance(point, units="km") == sqrt(4 + 4) / 1000
+        line = LineString([(2, 0), (2, 4), (3, 4)])
+        assert traj.frechet_distance(line, units="km") == sqrt(4 + 1) / 1000
+
+    def test_frechet_distance_warning(self):
+        with pytest.warns(UserWarning):
+            point = Point(0, 0)
+            self.default_traj_latlon.frechet_distance(point)
+
     """
     This test should work but fails in my PyCharm probably due to
     https://github.com/pyproj4/pyproj/issues/134

--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -1200,6 +1200,15 @@ class TestTrajectory:
             point = Point(0, 0)
             self.default_traj_latlon.frechet_distance(point)
 
+    def test_frechet_distance_requires_shapely_2(self, monkeypatch):
+        import shapely
+
+        traj = make_traj([Node(0, 0, day=1), Node(1, 1, day=2), Node(2, 2, day=3)])
+        # Simulate Shapely < 2.0, where the top-level frechet_distance is absent.
+        monkeypatch.delattr(shapely, "frechet_distance", raising=False)
+        with pytest.raises(NotImplementedError, match="Shapely >= 2.0"):
+            traj.frechet_distance(Point(0, 0))
+
     """
     This test should work but fails in my PyCharm probably due to
     https://github.com/pyproj4/pyproj/issues/134

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -1637,6 +1637,10 @@ class Trajectory:
         that takes into account the location and ordering of the points along
         the curves.
 
+        The distance is computed using Euclidean geometry, so a ``UserWarning``
+        is raised for trajectories in a geographic (lat/lon) CRS. Project to a
+        suitable planar CRS first for meaningful results.
+
         If units have been declared:
 
         - For geographic projections, in declared units

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -2,6 +2,7 @@
 
 import warnings
 
+import shapely
 from functools import wraps
 from shapely.affinity import translate
 from shapely.geometry import Point, LineString
@@ -1623,6 +1624,49 @@ class Trajectory:
         if isinstance(other, Trajectory):
             other = other.to_linestring()
         dist = self.to_linestring().hausdorff_distance(other)
+        conversion = get_conversion(units, self.crs_units)
+        return dist / conversion.distance
+
+    @requires_geometry
+    def frechet_distance(self, other, units=UNITS()):
+        """
+        Return the Fréchet distance to the other geometric object (based on
+        shapely
+        https://shapely.readthedocs.io/en/stable/reference/shapely.frechet_distance.html).
+        The Fréchet distance is a measure of the similarity between curves
+        that takes into account the location and ordering of the points along
+        the curves.
+
+        If units have been declared:
+
+        - For geographic projections, in declared units
+        - For known CRS units, in declared units
+        - For unknown CRS units, in declared units as if CRS is in meters
+
+        Parameters
+        ----------
+        other : shapely.geometry or Trajectory
+            Other geometric object or trajectory
+
+        units : str
+            Units in which to calculate distance values (default: CRS units)
+            For more info, check the list of supported units at
+            https://movingpandas.org/units
+
+        Returns
+        -------
+        float
+            Fréchet distance
+        """
+        if self.is_latlon:
+            message = (
+                f"Fréchet distance is computed using Euclidean geometry but "
+                f"the trajectory coordinate system is {self.crs}."
+            )
+            warnings.warn(message, UserWarning)
+        if isinstance(other, Trajectory):
+            other = other.to_linestring()
+        dist = shapely.frechet_distance(self.to_linestring(), other)
         conversion = get_conversion(units, self.crs_units)
         return dist / conversion.distance
 

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -1666,6 +1666,11 @@ class Trajectory:
             warnings.warn(message, UserWarning)
         if isinstance(other, Trajectory):
             other = other.to_linestring()
+        if not hasattr(shapely, "frechet_distance"):
+            raise NotImplementedError(
+                "Trajectory.frechet_distance() requires Shapely >= 2.0 "
+                f"(installed: {shapely.__version__}). Please upgrade Shapely."
+            )
         dist = shapely.frechet_distance(self.to_linestring(), other)
         conversion = get_conversion(units, self.crs_units)
         return dist / conversion.distance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "matplotlib",
     "geopandas",
     "geopy",
+    "shapely>=2.0",
 ]
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
This adds a `Trajectory.frechet_distance()` method, addressing part of #37 (trajectory distance measures).

Hausdorff distance is already implemented; this adds the (discrete) Fréchet distance. Unlike Hausdorff, the Fréchet distance takes the ordering of points along the curves into account, so it's often a more useful similarity measure for trajectories.

The method mirrors the existing `hausdorff_distance()` exactly — same `units` handling, the same lat/lon "computed using Euclidean geometry" warning, and the same support for `shapely.geometry` or `Trajectory` as `other`. It uses `shapely.frechet_distance`, which has been available since Shapely 2.0 (as noted in the issue thread by @mkh1991).

Added `test_frechet_distance`, `test_frechet_distance_units`, and `test_frechet_distance_warning`, mirroring the Hausdorff tests. `flake8` and `black` are clean on the additions.

DTW and LCSS from #37 are still open; happy to follow up in separate PRs.
