### PR TITLE
Add time zone handling to line and traj gdf output, fixes #487

### DIFF
--- a/movingpandas/tests/test_trajectory.py
+++ b/movingpandas/tests/test_trajectory.py
@@ -27,7 +27,6 @@ from . import (
     requires_geopandas1,
 )
 
-
 CRS_METRIC = CRS.from_user_input(31256)
 CRS_LATLON = CRS.from_user_input(4326)
 CRS_FEET = CRS.from_user_input(2964)
@@ -1020,6 +1019,43 @@ class TestTrajectory:
         geo_df = traj.df.copy()
         point_gdf = traj.to_point_gdf()
         assert_frame_equal(point_gdf, geo_df)
+
+    def test_to_point_gdf_return_tz_without_tz(self):
+        traj = self.default_traj_metric
+        point_gdf = traj.to_point_gdf(return_orig_tz=True)
+        assert_frame_equal(point_gdf, traj.df)
+
+    def test_to_line_gdf_return_tz(self):
+        traj = self.default_traj_metric_with_tz
+        line_gdf = traj.to_line_gdf(return_orig_tz=True)
+        expected = traj.to_line_gdf()
+        expected["t"] = expected["t"].dt.tz_localize(traj.df_orig_tz)
+        expected["prev_t"] = expected["prev_t"].dt.tz_localize(traj.df_orig_tz)
+        assert str(line_gdf["t"].dt.tz) == "CET"
+        assert str(line_gdf["prev_t"].dt.tz) == "CET"
+        assert_frame_equal(line_gdf, expected)
+
+    def test_to_line_gdf_dont_return_tz(self):
+        traj = self.default_traj_metric_with_tz
+        line_gdf = traj.to_line_gdf()
+        assert line_gdf["t"].dt.tz is None
+        assert line_gdf["prev_t"].dt.tz is None
+
+    def test_to_traj_gdf_return_tz(self):
+        traj = self.default_traj_metric_with_tz
+        traj_gdf = traj.to_traj_gdf(return_orig_tz=True)
+        expected = traj.to_traj_gdf()
+        expected["start_t"] = expected["start_t"].dt.tz_localize(traj.df_orig_tz)
+        expected["end_t"] = expected["end_t"].dt.tz_localize(traj.df_orig_tz)
+        assert str(traj_gdf["start_t"].dt.tz) == "CET"
+        assert str(traj_gdf["end_t"].dt.tz) == "CET"
+        assert_frame_equal(traj_gdf, expected)
+
+    def test_to_traj_gdf_dont_return_tz(self):
+        traj = self.default_traj_metric_with_tz
+        traj_gdf = traj.to_traj_gdf()
+        assert traj_gdf["start_t"].dt.tz is None
+        assert traj_gdf["end_t"].dt.tz is None
 
     def test_to_line_gdf(self):
         df = pd.DataFrame(

--- a/movingpandas/tests/test_trajectory_collection.py
+++ b/movingpandas/tests/test_trajectory_collection.py
@@ -584,6 +584,34 @@ class TestTrajectoryCollection:
 
         assert_frame_equal(traj_gdf, expected_line_gdf)
 
+    def test_to_point_gdf_return_tz(self):
+        geo_df_tz = self.geo_df.tz_localize("CET")
+        tc = TrajectoryCollection(geo_df_tz, traj_id_col="id", obj_id_col="obj")
+        point_gdf = tc.to_point_gdf(return_orig_tz=True)
+        assert_frame_equal(point_gdf, geo_df_tz)
+
+    def test_to_line_gdf_return_tz(self):
+        temp_df = self.geo_df.drop(columns=["obj", "val", "val2"]).tz_localize("CET")
+        tc = TrajectoryCollection(temp_df, "id")
+        line_gdf = tc.to_line_gdf(return_orig_tz=True)
+        assert str(line_gdf["t"].dt.tz) == "CET"
+        assert str(line_gdf["prev_t"].dt.tz) == "CET"
+        expected = tc.to_line_gdf()
+        expected["t"] = expected["t"].dt.tz_localize("CET")
+        expected["prev_t"] = expected["prev_t"].dt.tz_localize("CET")
+        assert_frame_equal(line_gdf, expected)
+
+    def test_to_traj_gdf_return_tz(self):
+        temp_df = self.geo_df.drop(columns=["obj", "val", "val2"]).tz_localize("CET")
+        tc = TrajectoryCollection(temp_df, "id")
+        traj_gdf = tc.to_traj_gdf(return_orig_tz=True)
+        assert str(traj_gdf["start_t"].dt.tz) == "CET"
+        assert str(traj_gdf["end_t"].dt.tz) == "CET"
+        expected = tc.to_traj_gdf()
+        expected["start_t"] = expected["start_t"].dt.tz_localize("CET")
+        expected["end_t"] = expected["end_t"].dt.tz_localize("CET")
+        assert_frame_equal(traj_gdf, expected)
+
     def test_to_traj_gdf_aggregate(self):
         temp_df = self.geo_df.drop(columns=["val2"])
         tc = TrajectoryCollection(temp_df, "id")

--- a/movingpandas/trajectory.py
+++ b/movingpandas/trajectory.py
@@ -156,8 +156,8 @@ class Trajectory:
         return df
 
     def _handle_timezone(self, df):
+        self.df_orig_tz = df.index.tzinfo
         if df.index.tzinfo is not None:
-            self.df_orig_tz = df.index.tzinfo
             warnings.warn(
                 "Time zone information dropped from trajectory. "
                 "All dates and times will use local time. "
@@ -637,14 +637,21 @@ class Trajectory:
         -------
         GeoDataFrame
         """
-        if return_orig_tz:
+        if return_orig_tz and self.df_orig_tz is not None:
             return self.df.tz_localize(self.df_orig_tz)
         return self.df
 
     @requires_geometry
-    def to_line_gdf(self, columns=None):
+    def to_line_gdf(self, columns=None, return_orig_tz=False):
         """
         Return the trajectory's line segments as GeoDataFrame.
+
+        Parameters
+        ----------
+        columns : list[string]
+            List of column names to copy from the trajectory dataframe
+        return_orig_tz : bool
+            If True, adds timezone info back to the t and prev_t columns
 
         Returns
         -------
@@ -657,10 +664,13 @@ class Trajectory:
         line_gdf.set_geometry("geometry", inplace=True)
         if self.crs:
             line_gdf.set_crs(self.crs, inplace=True)
+        if return_orig_tz and self.df_orig_tz is not None:
+            line_gdf["t"] = line_gdf["t"].dt.tz_localize(self.df_orig_tz)
+            line_gdf["prev_t"] = line_gdf["prev_t"].dt.tz_localize(self.df_orig_tz)
         return line_gdf
 
     @requires_geometry
-    def to_traj_gdf(self, wkt=False, agg=False):
+    def to_traj_gdf(self, wkt=False, agg=False, return_orig_tz=False):
         """
         Return a GeoDataFrame with one row containing the trajectory as a
         single LineString.
@@ -674,6 +684,8 @@ class Trajectory:
             columns according to specified aggregation mode, using
             pandas.DataFrame.agg(), and shortcuts for "mode" and quantiles
             (e.g. "q5" or "q95")
+        return_orig_tz : bool
+            If True, adds timezone info back to the start_t and end_t columns
 
         Examples
         --------
@@ -711,6 +723,9 @@ class Trajectory:
                     properties[f"{col}_{agg_mode}"] = aggregated
         df = DataFrame([properties])
         traj_gdf = GeoDataFrame(df, crs=self.crs)
+        if return_orig_tz and self.df_orig_tz is not None:
+            traj_gdf["start_t"] = traj_gdf["start_t"].dt.tz_localize(self.df_orig_tz)
+            traj_gdf["end_t"] = traj_gdf["end_t"].dt.tz_localize(self.df_orig_tz)
         return traj_gdf
 
     @requires_geometry

--- a/movingpandas/trajectory_collection.py
+++ b/movingpandas/trajectory_collection.py
@@ -162,40 +162,66 @@ class TrajectoryCollection:
         for traj in self.trajectories:
             traj.drop(**kwargs)
 
-    def to_point_gdf(self):
+    def to_point_gdf(self, return_orig_tz=False):
         """
         Return the trajectories' points as GeoDataFrame.
 
+        Parameters
+        ----------
+        return_orig_tz : bool
+            If True, adds timezone info back to the dataframe index
+
         Returns
         -------
         GeoDataFrame
         """
-        gdfs = [traj.to_point_gdf() for traj in self.trajectories]
+        gdfs = [traj.to_point_gdf(return_orig_tz) for traj in self.trajectories]
         return concat(gdfs)
 
-    def to_line_gdf(self, columns=None):
+    def to_line_gdf(self, columns=None, return_orig_tz=False):
         """
         Return the trajectories' line segments as GeoDataFrame.
 
+        Parameters
+        ----------
+        columns : list[string]
+            List of column names to copy from the trajectory dataframe
+        return_orig_tz : bool
+            If True, adds timezone info back to the t and prev_t columns
+
         Returns
         -------
         GeoDataFrame
         """
-        gdfs = [traj.to_line_gdf(columns) for traj in self.trajectories]
+        gdfs = [traj.to_line_gdf(columns, return_orig_tz) for traj in self.trajectories]
         gdf = concat(gdfs)
         gdf.reset_index(drop=True, inplace=True)
         return gdf
 
-    def to_traj_gdf(self, wkt=False, agg=False):
+    def to_traj_gdf(self, wkt=False, agg=False, return_orig_tz=False):
         """
         Return a GeoDataFrame with one row per Trajectory within the
         TrajectoryCollection
+
+        Parameters
+        ----------
+        wkt : bool
+            If True, adds WKT column representing the trajectory geometry
+        agg : dict
+            Adds columns with aggregate values computed from trajectory dataframe
+            columns according to specified aggregation mode, using
+            pandas.DataFrame.agg(), and shortcuts for "mode" and quantiles
+            (e.g. "q5" or "q95")
+        return_orig_tz : bool
+            If True, adds timezone info back to the start_t and end_t columns
 
         Returns
         -------
         GeoDataFrame
         """
-        gdfs = [traj.to_traj_gdf(wkt, agg) for traj in self.trajectories]
+        gdfs = [
+            traj.to_traj_gdf(wkt, agg, return_orig_tz) for traj in self.trajectories
+        ]
         gdf = concat(gdfs)
         gdf.reset_index(drop=True, inplace=True)
         return gdf


### PR DESCRIPTION
Extends the existing `return_orig_tz` option from `Trajectory.to_point_gdf` to `to_line_gdf` (`t`/`prev_t` columns) and `to_traj_gdf` (`start_t`/`end_t` columns), and exposes it on the `TrajectoryCollection` counterparts (`to_point_gdf`, `to_line_gdf`, `to_traj_gdf`).

Also initializes `df_orig_tz` for tz-naive input, so `return_orig_tz=True` no longer raises `AttributeError` on trajectories created without time zone info.

Defaults are unchanged (`return_orig_tz=False`), so existing behavior is unaffected. Adds 9 tests covering the new options at both the Trajectory and TrajectoryCollection level; Black and Flake8 are clean and the full test suite passes.

Fixes #487